### PR TITLE
dependencies: update jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.12.6.1</version>
+        <version>2.14.0-rc1</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.12.6</version>
+        <version>2.14.0-rc1</version>
         <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Update jackson dependencies to avoid CVE-2022-42003